### PR TITLE
Update cookie page to include Beamer cookies

### DIFF
--- a/src/pages/cookie.tsx
+++ b/src/pages/cookie.tsx
@@ -584,6 +584,82 @@ export default () => (
             <Td3>1 minute</Td3>
             <Td4>User activity won't be tracked</Td4>
           </Tr>
+          {/* new Beamer cookies */}
+          <Tr>
+            <Td1>_BEAMER_FIRST_VISIT_{'{productID}'}</Td1>
+            <Td2>Stores the date of this user’s first visit to the site.</Td2>
+            <Td3>300 days</Td3>
+            <Td4>User activity won't be tracked</Td4>
+          </Tr>
+          <Tr>
+            <Td1>_BEAMER_USER_ID_{'{productID}'}</Td1>
+            <Td2>Stores an internal ID for this user.</Td2>
+            <Td3>300 days</Td3>
+            <Td4>User activity won't be tracked</Td4>
+          </Tr>
+          <Tr>
+            <Td1>_BEAMER_LAST_UPDATE_{'{productID}'}</Td1>
+            <Td2>
+              Stores the timestamp for the last time the number of unread posts
+              was updated for this user.
+            </Td2>
+            <Td3>300 days</Td3>
+            <Td4>User activity won't be tracked</Td4>
+          </Tr>
+          <Tr>
+            <Td1>_BEAMER_FILTER_BY_URL_{'{productID}'}</Td1>
+            <Td2>Stores whether to apply URL filtering on the feed.</Td2>
+            <Td3>20 minutes</Td3>
+            <Td4>User activity won't be tracked</Td4>
+          </Tr>
+          <Tr>
+            <Td1>_BEAMER_DATE_{'{productID}'}</Td1>
+            <Td2>Stores the latest date in which the feed was opened.</Td2>
+            <Td3>300 days</Td3>
+            <Td4>User activity won't be tracked</Td4>
+          </Tr>
+          <Tr>
+            <Td1>_BEAMER_BOOSTED_ANNOUNCEMENT_DATE_{'{productID}'}</Td1>
+            <Td2>
+              Stores the latest date in which a boosted announcement was
+              displayed.
+            </Td2>
+            <Td3>300 days</Td3>
+            <Td4>User activity won't be tracked</Td4>
+          </Tr>
+          <Tr>
+            <Td1>_BEAMER_LAST_POST_SHOWN_{'{productID}'}</Td1>
+            <Td2>Stores the ID of the last post shown as a teaser.</Td2>
+            <Td3>300 days</Td3>
+            <Td4>User activity won't be tracked</Td4>
+          </Tr>
+          <Tr>
+            <Td1>_BEAMER_SOUND_PLAYED_{'{productID}'}</Td1>
+            <Td2>
+              Stores whether the notification sound was played since the last
+              time the feed was opened.
+            </Td2>
+            <Td3>7 days</Td3>
+            <Td4>User activity won't be tracked</Td4>
+          </Tr>
+          <Tr>
+            <Td1>_BEAMER_LAST_PUSH_PROMPT_INTERACTION_{'{productID}'}</Td1>
+            <Td2>
+              Stores the date of this user’s latest interaction with the prompt
+              requesting permission to send push notifications.
+            </Td2>
+            <Td3>300 days</Td3>
+            <Td4>User activity won't be tracked</Td4>
+          </Tr>
+          <Tr>
+            <Td1>_BEAMER_NPS_LAST_SHOWN_{'{productID}'}</Td1>
+            <Td2>
+              Stores the latest date in which the NPS prompt was shown to this
+              user.
+            </Td2>
+            <Td3>300 days</Td3>
+            <Td4>User activity won't be tracked</Td4>
+          </Tr>
         </Paragraph>
       </Section>
     </ContentWrapper>


### PR DESCRIPTION
## What it solves
Resolves #14

## How this PR fixes it
Includes the 3rd party cookies added by Beamer as present in https://www.getbeamer.com/docs#cookies

## How to test it
Verify that the "Cookie Policy" page display the rightful information as per Beamer official cookie documentation.

## Screenshots
![Screen Shot 2022-02-18 at 11 53 35](https://user-images.githubusercontent.com/32431609/154678328-8c4728d8-dbfe-4acd-8a45-8c5864dc597b.png)

