### PR TITLE
fix: wrong link

### DIFF
--- a/src/components/security/Main.tsx
+++ b/src/components/security/Main.tsx
@@ -169,7 +169,7 @@ const MainSection = () => {
             </a>
           </UsdWorthDate>
           <SButtonLink
-            url="https://gnosis-safe.io/security"
+            url="https://dune.com/safe/ethereum"
             target="_blank"
             explicitExternal
           >

--- a/src/components/security/Main.tsx
+++ b/src/components/security/Main.tsx
@@ -169,7 +169,7 @@ const MainSection = () => {
             </a>
           </UsdWorthDate>
           <SButtonLink
-            url="https://explore.duneanalytics.com/dashboard/gnosis-safe_2"
+            url="https://gnosis-safe.io/security"
             target="_blank"
             explicitExternal
           >


### PR DESCRIPTION
## What it solves

Resolves #68

## How this PR fixes it.

The incorrect link has been exchanged with the correct one (`https://dune.com/safe/ethereum`) on the security page.