### PR TITLE
fix: update Twitter link

### DIFF
--- a/src/components/home/Social.tsx
+++ b/src/components/home/Social.tsx
@@ -32,7 +32,7 @@ const Social: React.FC = () => (
     <ContentWrapper>
       <Row>
         <a
-          href="https://twitter.com/gnosisSafe"
+          href="https://twitter.com/safe"
           target="_blank"
           rel="noopener noreferrer"
         >

--- a/src/pages/terms.tsx
+++ b/src/pages/terms.tsx
@@ -922,8 +922,8 @@ export default () => (
           </Li>
           <Li>
             Twitter:{' '}
-            <Link href="https://twitter.com/gnosisSafe">
-              https://twitter.com/gnosisSafe
+            <Link href="https://twitter.com/safe">
+              https://twitter.com/safe
             </Link>
           </Li>
           <Li>


### PR DESCRIPTION
## What it solves

Incorrect Twitter link

## How this PR fixes it

The Twitter link at the bottom of the page has been updated to `@safe`.