### PR TITLE
fix: Update press kit footer link

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "safe-landing-page",
-  "version": "2.9.3",
+  "version": "2.9.4",
   "description": "Safe Landing Page",
   "private": true,
   "engines": {

--- a/src/components/Layout/Footer.tsx
+++ b/src/components/Layout/Footer.tsx
@@ -89,7 +89,7 @@ const Footer = ({ title }: FooterProps) => {
       </SLink>
       <Sep title={title}>|</Sep>
       <SLink
-        to="https://www.notion.so/Gnosis-Safe-Media-Kit-9b1fca2a566e40b8ac86396d788635b4"
+        to="https://gnosis-safe.notion.site/Safe-Media-Kit-35ce7ffc829c4bedbbf828464a1b7c00"
         target="_blank"
         rel="noopener noreferrer"
         title={title}


### PR DESCRIPTION
Updates the Press Kit footer link to the new notion page

Slack thread: https://5afe.slack.com/archives/C03DAGWJCR5/p1668429571440439

## How to test

1. Open then Landing page
2. Scroll down to the bottom
3. Click on Press Kit
4. Observe being navigated to the new brand notion page