### PR TITLE
Remove "Get in touch" buttons

### DIFF
--- a/src/components/enterprises/Main.tsx
+++ b/src/components/enterprises/Main.tsx
@@ -2,9 +2,7 @@ import React from 'react'
 import styled from 'styled-components'
 import LinesSVG from '../../assets/bg-lines-03.svg'
 import ContentWrapper from '../Layout/ContentWrapper'
-import ButtonLink from '../ui/ButtonLink'
 import Heading from '../ui/Heading'
-import { ENTERPRISES_CATEGORY, useAnalytics } from '../../utils/googleAnalytics'
 
 const Container = styled.main`
   height: calc(100vh - 56px);
@@ -55,33 +53,7 @@ const LCol = styled.div`
   flex-direction: column;
 `
 
-const ButtonsRow = styled.div`
-  display: flex;
-  justify-content: space-between;
-  width: 410px;
-  @media screen and (max-width: 980px) {
-    display: block;
-    width: 180px;
-  }
-`
-
-const SButtonLink = styled(ButtonLink)`
-  text-align: center;
-  width: 185px;
-  box-shadow: none;
-  padding: 0;
-  & > div {
-    width: 185px;
-    padding: 10px 20px;
-  }
-  @media screen and (max-width: 980px) {
-    margin-bottom: 20px;
-  }
-`
-
 const MainSection = () => {
-  const { trackEvent } = useAnalytics()
-
   return (
     <Container>
       <SLinesSVG />
@@ -90,26 +62,6 @@ const MainSection = () => {
           <SHeading>
             The digital asset management solution for enterprises
           </SHeading>
-          <ButtonsRow>
-            <SButtonLink
-              colorScheme="green"
-              url="https://gnosis1.typeform.com/to/Zt71a4yB"
-              target="_blank"
-              explicitExternal
-            >
-              <div
-                onClick={() =>
-                  trackEvent({
-                    category: ENTERPRISES_CATEGORY,
-                    action: 'Main section',
-                    label: 'Click Get in touch',
-                  })
-                }
-              >
-                Get in touch
-              </div>
-            </SButtonLink>
-          </ButtonsRow>
         </LCol>
       </SWrapper>
     </Container>

--- a/src/components/home/Main.tsx
+++ b/src/components/home/Main.tsx
@@ -76,7 +76,6 @@ const SButtonLink = styled(ButtonLink)`
 const SButtonLinkLeft = styled(SButtonLink)`
   margin-right: 20px;
 `
-const SButtonLinkRight = styled(SButtonLink)``
 
 const SLinesMainSVG = styled(LinesMainSVG)`
   position: absolute;
@@ -211,23 +210,6 @@ const MainSection = () => {
           </SHeading>
           <ButtonsRow>
             <SButtonLinkLeft
-              url="https://gnosis1.typeform.com/to/DOxbpZP3"
-              target="_blank"
-              explicitExternal
-            >
-              <div
-                onClick={() =>
-                  trackEvent({
-                    category: OVERVIEW_CATEGORY,
-                    action: 'Main section',
-                    label: 'Click Get in touch',
-                  })
-                }
-              >
-                Get in touch
-              </div>
-            </SButtonLinkLeft>
-            <SButtonLinkRight
               colorScheme="green"
               url="/#getting-started"
               target="_self"
@@ -244,7 +226,7 @@ const MainSection = () => {
               >
                 How it works
               </div>
-            </SButtonLinkRight>
+            </SButtonLinkLeft>
           </ButtonsRow>
         </LCol>
         <RCol>


### PR DESCRIPTION
This PR removes the "Get in touch" buttons.
The team is re-iterating this forms with the landing page and typeform migration.

## How to test

1. Open the landing page
2. Observe no Get in Touch button on the home page
3. Navigate to Enterprises
4. Observe no Get in Touch button