### PR TITLE
fix: Change gnosis-safe.io links to safe.global

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,7 @@
 
 # Deployed environments
 
-- Production: https://gnosis-safe.io
-- Staging: http://safe-team.staging.gnosisdev.com
-- Development: http://safe-team.dev.gnosisdev.com
+- Production: https://safe.global
 
 ## Getting Started
 

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -5,7 +5,7 @@ module.exports = {
   siteMetadata: {
     site: `safe`,
     description: `Safe is the most trusted platform to manage digital assets on Ethereum`,
-    siteUrl: `https://gnosis-safe.io`,
+    siteUrl: `https://safe.global`,
     language: `en`,
     color: `#003580`,
     twitter: 'safe',

--- a/src/components/Layout/Footer.tsx
+++ b/src/components/Layout/Footer.tsx
@@ -89,7 +89,7 @@ const Footer = ({ title }: FooterProps) => {
       </SLink>
       <Sep title={title}>|</Sep>
       <SLink
-        to="https://gnosis-safe.notion.site/Safe-Media-Kit-35ce7ffc829c4bedbbf828464a1b7c00"
+        to="https://press.safe.global"
         target="_blank"
         rel="noopener noreferrer"
         title={title}

--- a/src/components/Layout/Header/Header.tsx
+++ b/src/components/Layout/Header/Header.tsx
@@ -109,9 +109,9 @@ const SButtonLink = styled(ButtonLink)`
 `
 
 export const communityMenu: DropdownOption[] = [
-  { title: 'Forum', link: 'https://forum.gnosis-safe.io/' },
+  { title: 'Forum', link: 'https://forum.safe.global/' },
   { title: 'Chat', link: 'https://discord.gg/AjG7AQD9Qn' },
-  { title: 'Safe Guardians', link: 'https://guardians.gnosis-safe.io' },
+  { title: 'Safe Guardians', link: 'https://guardians.safe.global' },
 ]
 
 const useInterval = (delay = 2 * 60e3): number => {
@@ -170,7 +170,7 @@ const Header: React.FC<HeaderProps> = ({
             </NavListItem>
             <Divider />
             <NavListItem>
-              <NavListLink href="https://docs.gnosis-safe.io" target="_blank">
+              <NavListLink href="https://docs.safe.global" target="_blank">
                 <div
                   onClick={() =>
                     trackEvent({
@@ -190,7 +190,7 @@ const Header: React.FC<HeaderProps> = ({
             </NavListItem>
             <Divider />
             <NavListItem>
-              <NavListLink href="https://help.gnosis-safe.io" target="_blank">
+              <NavListLink href="https://help.safe.global" target="_blank">
                 <div
                   onClick={() =>
                     trackEvent({
@@ -211,7 +211,11 @@ const Header: React.FC<HeaderProps> = ({
             </NavListItem>
             <Divider />
             <NavListItem>
-              <SButtonLink url="https://app.safe.global" target="_self" explicitExternal>
+              <SButtonLink
+                url="https://app.safe.global"
+                target="_self"
+                explicitExternal
+              >
                 <div
                   onClick={() =>
                     trackEvent({

--- a/src/components/Layout/Header/Mobile/MobileMenu.tsx
+++ b/src/components/Layout/Header/Mobile/MobileMenu.tsx
@@ -99,7 +99,7 @@ const MobileMenu: React.FC<MobileMenuProps> = ({
             </NavLink>
           </NavListItem>
           <NavListItem>
-            <NavListLink href="https://docs.gnosis-safe.io" target="_blank">
+            <NavListLink href="https://docs.safe.global" target="_blank">
               <div
                 onClick={() =>
                   trackEvent({
@@ -118,7 +118,7 @@ const MobileMenu: React.FC<MobileMenuProps> = ({
           </NavListItem>
           {showCommunityMenu && <Dropdown options={communityMenu} />}
           <NavListItem>
-            <NavListLink href="https://help.gnosis-safe.io" target="_blank">
+            <NavListLink href="https://help.safe.global" target="_blank">
               <div
                 onClick={() =>
                   trackEvent({
@@ -138,7 +138,11 @@ const MobileMenu: React.FC<MobileMenuProps> = ({
             </NavLink>
           </NavListItem>
           <NavListItem>
-            <SButtonLink url="https://app.safe.global" target="_self" explicitExternal>
+            <SButtonLink
+              url="https://app.safe.global"
+              target="_self"
+              explicitExternal
+            >
               <div
                 onClick={() =>
                   trackEvent({

--- a/src/components/home/Features/index.tsx
+++ b/src/components/home/Features/index.tsx
@@ -260,9 +260,8 @@ const Features = () => {
               <Text>
                 <Title>Assets</Title>
                 <Description>
-                  Safe supports ETH, ERC20 (Tokens) and ERC721
-                  (NFTs). You can also see the fiat values of your
-                  assets.
+                  Safe supports ETH, ERC20 (Tokens) and ERC721 (NFTs). You can
+                  also see the fiat values of your assets.
                 </Description>
               </Text>
               <Image>
@@ -286,12 +285,11 @@ const Features = () => {
                 <Title>Safe Apps</Title>
                 <Description>
                   Bringing multisig security to DeFi, you can now put your funds
-                  to work directly from the Safe interface. Use your
-                  digital assets to invest, earn, borrow, invoice, do payroll
-                  and more.
+                  to work directly from the Safe interface. Use your digital
+                  assets to invest, earn, borrow, invoice, do payroll and more.
                   <br />
                   <a
-                    href="https://help.gnosis-safe.io/en/articles/4022022-what-are-safe-apps"
+                    href="https://help.safe.global/en/articles/4022022-what-are-safe-apps"
                     target="_blank"
                   >
                     <InnerLink

--- a/src/components/home/GettingStarted.tsx
+++ b/src/components/home/GettingStarted.tsx
@@ -126,7 +126,7 @@ const GettingStarted = () => {
         <SHeading>Getting started</SHeading>
         <Row>
           <Link
-            href="https://help.gnosis-safe.io/en/articles/3876456-what-is-gnosis-safe"
+            href="https://help.safe.global/en/articles/3876456-what-is-gnosis-safe"
             target="_blank"
             rel="noopener noreferrer"
           >
@@ -142,8 +142,8 @@ const GettingStarted = () => {
               <CardItem>
                 <Title>What is Safe?</Title>
                 <Text>
-                  Read about the basics of Safe and how it compares to
-                  other solutions
+                  Read about the basics of Safe and how it compares to other
+                  solutions
                 </Text>
                 <SLinkIcon>
                   <LinkIcon />
@@ -152,7 +152,7 @@ const GettingStarted = () => {
             </div>
           </Link>
           <Link
-            href="https://help.gnosis-safe.io/en/articles/3876461-create-a-gnosis-safe-account"
+            href="https://help.safe.global/en/articles/3876461-create-a-gnosis-safe-account"
             target="_blank"
             rel="noopener noreferrer"
           >
@@ -168,8 +168,8 @@ const GettingStarted = () => {
               <CardItem>
                 <Title>Create a Safe account</Title>
                 <Text>
-                  The full process of creating a new Safe account in just
-                  60 seconds
+                  The full process of creating a new Safe account in just 60
+                  seconds
                 </Text>
                 <SLinkIcon>
                   <LinkIcon />
@@ -178,7 +178,7 @@ const GettingStarted = () => {
             </div>
           </Link>
           <Link
-            href="https://help.gnosis-safe.io/en/articles/4772567-what-gnosis-safe-setup-should-i-use"
+            href="https://help.safe.global/en/articles/4772567-what-gnosis-safe-setup-should-i-use"
             target="_blank"
             rel="noopener noreferrer"
           >
@@ -204,7 +204,7 @@ const GettingStarted = () => {
             </div>
           </Link>
           <Link
-            href="https://help.gnosis-safe.io/en/articles/4290276-costs-of-creating-a-gnosis-safe-account"
+            href="https://help.safe.global/en/articles/4290276-costs-of-creating-a-gnosis-safe-account"
             target="_blank"
             rel="noopener noreferrer"
           >
@@ -213,8 +213,7 @@ const GettingStarted = () => {
                 trackEvent({
                   category: OVERVIEW_CATEGORY,
                   action: 'Getting started section',
-                  label:
-                    'Open article: Costs of creating a Safe account',
+                  label: 'Open article: Costs of creating a Safe account',
                 })
               }
             >

--- a/src/components/home/Main.tsx
+++ b/src/components/home/Main.tsx
@@ -252,7 +252,7 @@ const MainSection = () => {
             <video width="100%" autoPlay muted ref={videoRef}>
               <source
                 type="video/mp4"
-                src="https://gnosis-safe.io/gnosis-safe-final.mp4"
+                src="https://safe.global/gnosis-safe-final.mp4"
               />
             </video>
             <PlayIcon onClick={playVideo} />

--- a/src/components/security/BugBounty/index.tsx
+++ b/src/components/security/BugBounty/index.tsx
@@ -110,7 +110,7 @@ const BugBounty = () => {
           <LCol>
             <LHeading>Our biggest bug bounty program ever</LHeading>
             <SButtonLink
-              url="https://docs.gnosis-safe.io/introduction/security/bug-bounty-program"
+              url="https://docs.safe.global/introduction/security/bug-bounty-program"
               colorScheme="white"
             >
               <div


### PR DESCRIPTION
As discussed in [Slack](https://5afe.slack.com/archives/C03DAGWJCR5/p1668429571440439)

## What it solves

- Updates gnosis-safe.io links to safe.global
- Updates the README

## How to test

- Open the landing page
- Observe no links that go to gnosis-safe.io except on the terms page (this will be updated at a later time)