### PR TITLE
fix: careers tagline + no positions message

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "safe-landing-page",
-  "version": "2.9.10",
+  "version": "2.9.11",
   "description": "Safe Landing Page",
   "private": true,
   "engines": {

--- a/src/components/careers/Header/index.tsx
+++ b/src/components/careers/Header/index.tsx
@@ -123,13 +123,12 @@ const Header = ({ openPositions }: { openPositions: number | undefined }) => {
               <Grid item xs={12} md={6}>
                 <FeatureText>
                   By designing fairer markets, we aim to build a more evenly
-                  distributed future, together. Be a part of a team building
-                  leading decentralized finance products.
+                  distributed future, together.
                 </FeatureText>
               </Grid>
-            </Grid>
-            <Grid item xs={12}>
-              <AnchorLink href="#positions">Explore positions</AnchorLink>
+              <Grid item xs={12}>
+                <AnchorLink href="#positions">Explore positions</AnchorLink>
+              </Grid>
             </Grid>
           </div>
         </ContentWrapper>

--- a/src/components/careers/Positions/index.tsx
+++ b/src/components/careers/Positions/index.tsx
@@ -54,12 +54,12 @@ const Section = styled.section`
   }
 `
 
-const Positions = ({ positions }: { positions: Job[] | undefined }) => {
+const Positions = ({ positions }: { positions: Job[] }) => {
   return (
     <Section>
       <ContentWrapper>
         <SectionTitle id="positions">Open positions</SectionTitle>
-        {!positions ? (
+        {positions.length === 0 ? (
           <Text>
             Unfortunately, there are <strong>no positions available</strong> at
             the moment. However, you can always send us your CV and we will get


### PR DESCRIPTION
## What it solves

- Adjusts tagline on careers page
- Shows message when no positions are found

## How to test

Open the careers page and observe the new tagline. Blocking the Breezy request and refreshing will show the no open positions message.

## Screenshots

![image](https://user-images.githubusercontent.com/20442784/216663181-c1a2f240-6094-4256-8dc4-4c0619913e96.png)

![image](https://user-images.githubusercontent.com/20442784/216663286-fe44f247-3232-4a89-bb9c-7da7ba210d52.png)

## Links

- [Discussion](https://5afe.slack.com/archives/C03BHKS5K6D/p1675438835801159)